### PR TITLE
Threadpool updated close

### DIFF
--- a/src/main/java/com/darylteo/nio/DirectoryWatcher.java
+++ b/src/main/java/com/darylteo/nio/DirectoryWatcher.java
@@ -275,7 +275,7 @@ public class DirectoryWatcher {
 
     for (String sub : subs) {
       if (appendDelimiter) {
-        pattern.append(File.separator);
+        pattern.append("[/|\\\\]");
       } else {
         appendDelimiter = true;
       }
@@ -287,7 +287,7 @@ public class DirectoryWatcher {
         pattern.append(sub
           .replace(".", "\\.")
           .replace("?", ".")
-          .replace("*", "[^" + File.separator + "]*?")
+          .replace("*", "[^/|\\\\]*?")
           );
       }
     }
@@ -295,7 +295,7 @@ public class DirectoryWatcher {
     pattern.append("$");
     return Pattern.compile(pattern.toString());
   }
-
+  
   /* Filter Checking */
   public boolean shouldTrack(Path path) {
     return shouldTrack(path.toString());

--- a/src/test/java/com/darylteo/nio/tests/DirectoryWatcherFilterTest.java
+++ b/src/test/java/com/darylteo/nio/tests/DirectoryWatcherFilterTest.java
@@ -239,4 +239,15 @@ public class DirectoryWatcherFilterTest {
     assertFalse(watcher.shouldTrack(Paths.get("foo/file.json")));
     assertFalse(watcher.shouldTrack(Paths.get("foo/bar/file.json")));
   }
+  
+  @Test
+  public void testWindows() throws InterruptedException, IOException {
+    watcher.exclude("foo\\**");
+
+    assertTrue(watcher.shouldTrack(Paths.get("file")));
+    assertTrue(watcher.shouldTrack(Paths.get("file.json")));
+    assertFalse(watcher.shouldTrack(Paths.get("foo\\file")));
+    assertFalse(watcher.shouldTrack(Paths.get("foo\\file.json")));
+    assertFalse(watcher.shouldTrack(Paths.get("foo\\bar\\file.json")));
+  }
 }


### PR DESCRIPTION
Still had some issues within a JavaFX application, where the spawned thread was still alive after calling `shutdownNow()` (see #1 ). The applied changes fix the issue for me.
